### PR TITLE
Switch to use librato fork of go-syslog (AO-17102)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   allow_failures:
     - go: tip
 
-go_import_path: gopkg.in/mcuadros/go-syslog.v2
+go_import_path: github.com/librato/go-syslog
 
 install:
   - go get -v -t ./...

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 The recommended way to install go-syslog
 
 ```
-go get gopkg.in/mcuadros/go-syslog.v2
+go get github.com/librato/go-syslog
 ```
 
 Examples
@@ -18,7 +18,7 @@ Examples
 How import the package
 
 ```go
-import "gopkg.in/mcuadros/go-syslog.v2"
+import "github.com/librato/go-syslog"
 ```
 
 Example of a basic syslog [UDP server](example/basic_udp.go):

--- a/doc.go
+++ b/doc.go
@@ -2,4 +2,4 @@
 Syslog server library for go, build easy your custom syslog server
 over UDP, TCP or Unix sockets using RFC3164, RFC5424 and RFC6587
 */
-package syslog // import "gopkg.in/mcuadros/go-syslog.v2"
+package syslog // import "github.com/librato/go-syslog"

--- a/example/basic_udp.go
+++ b/example/basic_udp.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"gopkg.in/mcuadros/go-syslog.v2"
+	"github.com/librato/go-syslog"
 )
 
 func main() {

--- a/format/automatic.go
+++ b/format/automatic.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"strconv"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164"
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc3164"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc5424"
 )
 
 /* Selecting an 'Automatic' format detects incoming format (i.e. RFC3164 vs RFC5424) and Framing

--- a/format/format.go
+++ b/format/format.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"time"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
+	"github.com/librato/go-syslog/internal/syslogparser"
 )
 
 type LogParts map[string]interface{}

--- a/format/rfc3164.go
+++ b/format/rfc3164.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bufio"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc3164"
 )
 
 type RFC3164 struct{}

--- a/format/rfc5424.go
+++ b/format/rfc5424.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bufio"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc5424"
 )
 
 type RFC5424 struct{}

--- a/format/rfc6587.go
+++ b/format/rfc6587.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"strconv"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc5424"
 )
 
 type RFC6587 struct{}

--- a/handler.go
+++ b/handler.go
@@ -1,7 +1,7 @@
 package syslog
 
 import (
-	"gopkg.in/mcuadros/go-syslog.v2/format"
+	"github.com/librato/go-syslog/format"
 )
 
 //The handler receive every syslog entry at Handle method

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,8 +1,8 @@
 package syslog
 
 import (
+	"github.com/librato/go-syslog/format"
 	. "gopkg.in/check.v1"
-	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 type HandlerSuite struct{}

--- a/internal/syslogparser/rfc3164/example_test.go
+++ b/internal/syslogparser/rfc3164/example_test.go
@@ -3,7 +3,7 @@ package rfc3164_test
 import (
 	"fmt"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc3164"
 )
 
 func ExampleNewParser() {

--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
+	"github.com/librato/go-syslog/internal/syslogparser"
 )
 
 type Parser struct {

--- a/internal/syslogparser/rfc3164/rfc3164_test.go
+++ b/internal/syslogparser/rfc3164/rfc3164_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/librato/go-syslog/internal/syslogparser"
 	. "gopkg.in/check.v1"
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 )
 
 // Hooks up gocheck into the gotest runner.

--- a/internal/syslogparser/rfc5424/example_test.go
+++ b/internal/syslogparser/rfc5424/example_test.go
@@ -3,7 +3,7 @@ package rfc5424_test
 import (
 	"fmt"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
+	"github.com/librato/go-syslog/internal/syslogparser/rfc5424"
 )
 
 func ExampleNewParser() {

--- a/internal/syslogparser/rfc5424/rfc5424.go
+++ b/internal/syslogparser/rfc5424/rfc5424.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
+	"github.com/librato/go-syslog/internal/syslogparser"
 )
 
 const (

--- a/internal/syslogparser/rfc5424/rfc5424_test.go
+++ b/internal/syslogparser/rfc5424/rfc5424_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/librato/go-syslog/internal/syslogparser"
 	. "gopkg.in/check.v1"
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 )
 
 // Hooks up gocheck into the gotest runner.

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/mcuadros/go-syslog.v2/format"
+	"github.com/librato/go-syslog/format"
 )
 
 var (

--- a/server_bench_test.go
+++ b/server_bench_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/mcuadros/go-syslog.v2/format"
+	"github.com/librato/go-syslog/format"
 )
 
 type noopFormatter struct{}

--- a/server_test.go
+++ b/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/librato/go-syslog/format"
 	. "gopkg.in/check.v1"
-	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
Switch to use librato fork of go-syslog (AO-17102)

* Fixed imports after repository fork

JIRA: (AO-17102)